### PR TITLE
Add night sky background

### DIFF
--- a/index.html
+++ b/index.html
@@ -9583,6 +9583,14 @@
     <script src="./ホーム _ Mysite_files/rb_wixui.thunderbolt[Container_DefaultAreaSkin].14889bc3.bundle.min.js.ダウンロード"></script>
     <script src="./ホーム _ Mysite_files/rb_wixui.thunderbolt[TextMask].77755902.bundle.min.js.ダウンロード"></script>
     <script src="./ホーム _ Mysite_files/rb_wixui.thunderbolt[WPhoto_RoundPhoto].ad1c505e.bundle.min.js.ダウンロード"></script>
+<style>
+  body {
+    background-image: url("src/night-sky.svg");
+    background-size: cover;
+    background-repeat: no-repeat;
+    background-attachment: fixed;
+  }
+</style>
 </head>
 <body class="">
 <script type="text/javascript">

--- a/src/night-sky.svg
+++ b/src/night-sky.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1920" height="1080" viewBox="0 0 1920 1080">
+  <defs>
+    <linearGradient id="skyGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#001"/>
+      <stop offset="100%" stop-color="#000"/>
+    </linearGradient>
+  </defs>
+  <rect width="1920" height="1080" fill="url(#skyGrad)"/>
+  <g fill="white">
+    <circle cx="200" cy="100" r="2"/>
+    <circle cx="400" cy="250" r="1.5"/>
+    <circle cx="600" cy="150" r="2"/>
+    <circle cx="800" cy="300" r="1"/>
+    <circle cx="1000" cy="80" r="1.5"/>
+    <circle cx="1200" cy="200" r="2"/>
+    <circle cx="1400" cy="120" r="1"/>
+    <circle cx="1600" cy="250" r="2"/>
+    <circle cx="1800" cy="90" r="1.5"/>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
- create a simple SVG showing a night sky with stars
- use that SVG as the page background

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683fc8acf11883228e711305b2087998